### PR TITLE
Added support for IHttpClientFactory

### DIFF
--- a/Autofocus/Autofocus.csproj
+++ b/Autofocus/Autofocus.csproj
@@ -17,4 +17,8 @@
     <Folder Include="Extensions\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Autofocus/StableDiffusion.cs
+++ b/Autofocus/StableDiffusion.cs
@@ -23,8 +23,8 @@ public class StableDiffusion
         }
     };
 
-    private HttpClient SlowHttpClient { get; } = new();
-    internal HttpClient FastHttpClient { get; } = new();
+    private HttpClient SlowHttpClient { get; }
+    internal HttpClient FastHttpClient { get; }
 
     /// <summary>
     /// Timeout used for "fast" operations (anything that's not image processing)
@@ -50,8 +50,19 @@ public class StableDiffusion
 
     }
 
-    public StableDiffusion(Uri address)
+    public StableDiffusion(Uri address, IHttpClientFactory? factory = null, string? httpClientName = null)
     {
+        if (factory == null)
+        {
+            SlowHttpClient = new();
+            FastHttpClient = new();
+        }
+        else
+        {
+            SlowHttpClient = httpClientName == null ? factory.CreateClient() : factory.CreateClient(httpClientName);
+            FastHttpClient = httpClientName == null ? factory.CreateClient() : factory.CreateClient(httpClientName);
+        }
+
         SlowHttpClient.BaseAddress = address;
         SlowHttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Autofocus Agent");
 


### PR DESCRIPTION
As per [recommended guidelines](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines), you should not directly create short-lived instances of `HttpClient`. This PR adds support for the `IHttpClientFactory` pattern and also includes support for named HttpClients.