### PR TITLE
Added CancellationToken

### DIFF
--- a/Autofocus/IStableDiffusion.cs
+++ b/Autofocus/IStableDiffusion.cs
@@ -1,48 +1,96 @@
 ﻿using Autofocus.Config;
 using Autofocus.Models;
+using Autofocus.Scripts;
 
 namespace Autofocus
 {
     public interface IStableDiffusion
     {
-        public Task<IProgress> Progress(bool skipCurrentImage = false);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IProgress> Progress(bool skipCurrentImage = false, CancellationToken cancellationToken = default);
 
-        public Task Ping();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task Ping(CancellationToken cancellationToken = default);
 
-        public Task<IQueueStatus> QueueStatus();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IQueueStatus> QueueStatus(CancellationToken cancellationToken = default);
 
-        public Task<IScriptsResponse> Scripts();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IScriptsResponse> Scripts(CancellationToken cancellationToken = default);
 
-        public Task<IEnumerable<ISampler>> Samplers();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IEnumerable<ISampler>> Samplers(CancellationToken cancellationToken = default);
 
-        public Task<ISampler> Sampler(string name);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="InvalidOperationException"/>  
+		/// <exception cref="OperationCanceledException"/>
+		public Task<ISampler> Sampler(string name, CancellationToken cancellationToken = default);
 
-        public Task<IEnumerable<IUpscaler>> Upscalers();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IEnumerable<IUpscaler>> Upscalers(CancellationToken cancellationToken = default);
 
-        public Task<IUpscaler> Upscaler(string name);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="InvalidOperationException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IUpscaler> Upscaler(string name, CancellationToken cancellationToken = default);
 
-        public Task<IEnumerable<IPromptStyle>> Styles();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IEnumerable<IPromptStyle>> Styles(CancellationToken cancellationToken = default);
 
-        public Task<IPromptStyle> Style(string name);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="InvalidOperationException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IPromptStyle> Style(string name, CancellationToken cancellationToken = default);
 
-        public Task<IEnumerable<IStableDiffusionModel>> StableDiffusionModels();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IEnumerable<IStableDiffusionModel>> StableDiffusionModels(CancellationToken cancellationToken = default);
 
-        public Task<IStableDiffusionModel> StableDiffusionModel(string name);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="InvalidOperationException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IStableDiffusionModel> StableDiffusionModel(string name, CancellationToken cancellationToken = default);
 
-        public Task<IEmbeddings> Embeddings();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IEmbeddings> Embeddings(CancellationToken cancellationToken = default);
 
-        public Task<IMemory> Memory();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IMemory> Memory(CancellationToken cancellationToken = default);
 
-        public Task<IPngInfo> PngInfo(Base64EncodedImage image);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IPngInfo> PngInfo(Base64EncodedImage image, CancellationToken cancellationToken = default);
 
-        public Task<ITextToImageResult> TextToImage(TextToImageConfig config);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		/// <exception cref="ScriptNotFoundException"/>
+		public Task<ITextToImageResult> TextToImage(TextToImageConfig config, CancellationToken cancellationToken = default);
 
-        public Task<IImageToImageResult> Image2Image(ImageToImageConfig config);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		/// <exception cref="ScriptNotFoundException"/>
+		public Task<IImageToImageResult> Image2Image(ImageToImageConfig config, CancellationToken cancellationToken = default);
 
-        public Task<IInterrogateResult> Interrogate(Base64EncodedImage image, InterrogateModel model = InterrogateModel.CLIP);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IInterrogateResult> Interrogate(Base64EncodedImage image, InterrogateModel model = InterrogateModel.CLIP, CancellationToken cancellationToken = default);
 
-        public Task<IInterrogateResult> Interrogate(InterrogateConfig config);
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<IInterrogateResult> Interrogate(InterrogateConfig config, CancellationToken cancellationToken = default);
 
-        public Task<ControlNet?> TryGetControlNet();
+		/// <exception cref="HttpRequestException"/>
+		/// <exception cref="InvalidOperationException"/>
+		/// <exception cref="OperationCanceledException"/>
+		public Task<ControlNet?> TryGetControlNet(CancellationToken cancellationToken = default);
     }
 }

--- a/Autofocus/StableDiffusion.cs
+++ b/Autofocus/StableDiffusion.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -77,45 +78,56 @@ public class StableDiffusion
         }
     }
 
-    public async Task<IProgress> Progress(bool skipCurrentImage = false)
+    /// <inheritdoc />
+    public async Task<IProgress> Progress(bool skipCurrentImage = false, CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<ProgressResponse>($"/sdapi/v1/progress?skip_current_image={skipCurrentImage}", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<ProgressResponse>($"/sdapi/v1/progress?skip_current_image={skipCurrentImage}",
+            SerializerOptions, cancellationToken))!;
     }
 
-    public async Task Ping()
+    /// <inheritdoc />
+    public async Task Ping(CancellationToken cancellationToken = default)
     {
-        (await FastHttpClient.GetAsync($"/internal/ping")).EnsureSuccessStatusCode();
+        (await FastHttpClient.GetAsync($"/internal/ping", cancellationToken)).EnsureSuccessStatusCode();
     }
 
-    public async Task<IQueueStatus> QueueStatus()
+    /// <inheritdoc />
+    public async Task<IQueueStatus> QueueStatus(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<QueueStatusResponse>($"/queue/status", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<QueueStatusResponse>($"/queue/status", SerializerOptions, cancellationToken))!;
     }
 
     #region scripts
-    public async Task<IScriptsResponse> Scripts()
+    /// <inheritdoc />
+    public async Task<IScriptsResponse> Scripts(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<ScriptsResponse>("/sdapi/v1/scripts", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<ScriptsResponse>("/sdapi/v1/scripts", SerializerOptions, cancellationToken))!;
     }
     #endregion
 
     #region sampler
-    public async Task<IEnumerable<ISampler>> Samplers()
+    /// <inheritdoc />
+    public async Task<IEnumerable<ISampler>> Samplers(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<SamplerResponse[]>("/sdapi/v1/samplers", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<SamplerResponse[]>("/sdapi/v1/samplers", SerializerOptions, cancellationToken))!;
     }
 
-    public async Task<ISampler> Sampler(string name)
+    /// <inheritdoc />
+    public async Task<ISampler> Sampler(string name, CancellationToken cancellationToken = default)
     {
-        var samplers = await Samplers();
+        var samplers = await Samplers(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         return samplers.Single(a => a.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
     }
     #endregion
 
     #region upscaler
-    public async Task<IEnumerable<IUpscaler>> Upscalers()
+    /// <inheritdoc />
+    public async Task<IEnumerable<IUpscaler>> Upscalers(CancellationToken cancellationToken = default)
     {
-        var upscalers = await FastHttpClient.GetFromJsonAsync<UpscalerResponse[]>("/sdapi/v1/upscalers", SerializerOptions);
+        var upscalers = await FastHttpClient.GetFromJsonAsync<UpscalerResponse[]>("/sdapi/v1/upscalers", SerializerOptions, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         for (var i = 0; i < upscalers!.Length; i++)
             upscalers[i].Index = i;
@@ -123,155 +135,191 @@ public class StableDiffusion
         return upscalers;
     }
 
-    public async Task<IUpscaler> Upscaler(string name)
+    /// <inheritdoc />
+    public async Task<IUpscaler> Upscaler(string name, CancellationToken cancellationToken = default)
     {
-        var models = await Upscalers();
+        var models = await Upscalers(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         return models.Single(a => a.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
     }
     #endregion
 
     #region style
-    public async Task<IEnumerable<IPromptStyle>> Styles()
+    /// <inheritdoc />
+    public async Task<IEnumerable<IPromptStyle>> Styles(CancellationToken cancellationToken)
     {
-        return (await FastHttpClient.GetFromJsonAsync<PromptStyleResponse[]>("/sdapi/v1/prompt-styles", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<PromptStyleResponse[]>("/sdapi/v1/prompt-styles", SerializerOptions, cancellationToken))!;
     }
 
-    public async Task<IPromptStyle> Style(string name)
+    /// <inheritdoc />
+    public async Task<IPromptStyle> Style(string name, CancellationToken cancellationToken = default)
     {
-        var styles = await Styles();
+        var styles = await Styles(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         return styles.Single(a => a.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
     }
     #endregion
 
     #region SD models
-    public async Task<IEnumerable<IStableDiffusionModel>> StableDiffusionModels()
+    /// <inheritdoc />
+    public async Task<IEnumerable<IStableDiffusionModel>> StableDiffusionModels(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<StableDiffusionModelResponse[]>("/sdapi/v1/sd-models", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<StableDiffusionModelResponse[]>("/sdapi/v1/sd-models", SerializerOptions, cancellationToken))!;
     }
 
-    public async Task<IStableDiffusionModel> StableDiffusionModel(string name)
+    /// <inheritdoc />
+    public async Task<IStableDiffusionModel> StableDiffusionModel(string name, CancellationToken cancellationToken = default)
     {
-        var models = await StableDiffusionModels();
+        var models = await StableDiffusionModels(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         return models.Single(a => a.ModelName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
     }
     #endregion
 
     #region embeddings
-    public async Task<IEmbeddings> Embeddings()
+    /// <inheritdoc />
+    public async Task<IEmbeddings> Embeddings(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<EmbeddingsResponse>("/sdapi/v1/embeddings", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<EmbeddingsResponse>("/sdapi/v1/embeddings", SerializerOptions, cancellationToken))!;
     }
     #endregion
 
     #region memory
-    public async Task<IMemory> Memory()
+    /// <inheritdoc />
+    public async Task<IMemory> Memory(CancellationToken cancellationToken = default)
     {
-        return (await FastHttpClient.GetFromJsonAsync<MemoryResponse>("/sdapi/v1/memory", SerializerOptions))!;
+        return (await FastHttpClient.GetFromJsonAsync<MemoryResponse>("/sdapi/v1/memory", SerializerOptions, cancellationToken))!;
     }
     #endregion
 
     #region PNG Info
-    public async Task<IPngInfo> PngInfo(Base64EncodedImage image)
+    /// <inheritdoc />
+    public async Task<IPngInfo> PngInfo(Base64EncodedImage image, CancellationToken cancellationToken = default)
     {
         var request = new PngInfoRequest(image);
 
-        var response = await FastHttpClient.PostAsJsonAsync("/sdapi/v1/png-info", request, SerializerOptions);
+        var response = await FastHttpClient.PostAsJsonAsync("/sdapi/v1/png-info", request, SerializerOptions, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var result = await response
             .EnsureSuccessStatusCode()
             .Content
-            .ReadFromJsonAsync<PngInfoResponse>();
+            .ReadFromJsonAsync<PngInfoResponse>(cancellationToken: cancellationToken);
 
         return result!;
     }
-    #endregion
+	#endregion
 
-    #region Text2Image
-    private async Task CheckTxt2ImgScript(string? name)
+	#region Text2Image
+	/// <exception cref="HttpRequestException"/>
+	/// <exception cref="OperationCanceledException"/>
+	/// <exception cref="ScriptNotFoundException"/>
+	private async Task CheckTxt2ImgScript(string? name, CancellationToken cancellationToken)
     {
         if (name == null)
             return;
 
-        var scripts = await Scripts();
+        var scripts = await Scripts(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (!scripts.Txt2Img.Contains(name))
             throw new ScriptNotFoundException(name);
     }
 
-    public async Task<ITextToImageResult> TextToImage(TextToImageConfig config)
+    /// <inheritdoc />
+    public async Task<ITextToImageResult> TextToImage(TextToImageConfig config, CancellationToken cancellationToken = default)
     {
-        await CheckTxt2ImgScript(config.Script?.Key);
+        await CheckTxt2ImgScript(config.Script?.Key, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var request = new TextToImageConfigRequest(config);
 
-        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/txt2img", request, SerializerOptions);
+        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/txt2img", request, SerializerOptions, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var result = await response
                           .EnsureSuccessStatusCode()
                           .Content
-                          .ReadFromJsonAsync<TextToImageResultResponse>(SerializerOptions);
+                          .ReadFromJsonAsync<TextToImageResultResponse>(SerializerOptions, cancellationToken);
 
         return result!;
     }
-    #endregion
+	#endregion
 
-    #region Image2Image
-    private async Task CheckImg2ImgScript(string? name)
+	#region Image2Image
+	/// <exception cref="HttpRequestException"/>
+	/// <exception cref="OperationCanceledException"/>
+	/// <exception cref="ScriptNotFoundException"/>
+	private async Task CheckImg2ImgScript(string? name, CancellationToken cancellationToken)
     {
         if (name == null)
             return;
 
-        var scripts = await Scripts();
+        var scripts = await Scripts(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (!scripts.Img2Img.Contains(name))
             throw new ScriptNotFoundException(name);
     }
 
-    public async Task<IImageToImageResult> Image2Image(ImageToImageConfig config)
+    /// <inheritdoc />
+    public async Task<IImageToImageResult> Image2Image(ImageToImageConfig config, CancellationToken cancellationToken = default)
     {
-        await CheckImg2ImgScript(config.Script?.Key);
+        await CheckImg2ImgScript(config.Script?.Key, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var request = new ImageToImageConfigRequest(config);
 
-        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/img2img", request, SerializerOptions);
+        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/img2img", request, SerializerOptions, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var result = await response
                           .EnsureSuccessStatusCode()
                           .Content
-                          .ReadFromJsonAsync<ImageToImageResultResponse>(SerializerOptions);
+                          .ReadFromJsonAsync<ImageToImageResultResponse>(SerializerOptions, cancellationToken);
 
         return result!;
     }
     #endregion
 
     #region interrogate
-    public Task<IInterrogateResult> Interrogate(Base64EncodedImage image, InterrogateModel model = InterrogateModel.CLIP)
+    /// <inheritdoc />
+    public Task<IInterrogateResult> Interrogate(Base64EncodedImage image, InterrogateModel model = InterrogateModel.CLIP, CancellationToken cancellationToken = default)
     {
         return Interrogate(new InterrogateConfig
         {
             Image = image,
             Model = model,
-        });
+        }, cancellationToken);
     }
 
-    public async Task<IInterrogateResult> Interrogate(InterrogateConfig config)
+    /// <inheritdoc />
+    public async Task<IInterrogateResult> Interrogate(InterrogateConfig config, CancellationToken cancellationToken = default)
     {
         var request = new InterrogateConfigRequest(config);
 
-        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/interrogate", request, SerializerOptions);
+        var response = await SlowHttpClient.PostAsJsonAsync("/sdapi/v1/interrogate", request, SerializerOptions, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var result = await response
                           .EnsureSuccessStatusCode()
                           .Content
-                          .ReadFromJsonAsync<InterrogateResultResponse>(SerializerOptions);
+                          .ReadFromJsonAsync<InterrogateResultResponse>(SerializerOptions, cancellationToken);
 
         return result!;
     }
     #endregion
 
     #region controlnet
-    public async Task<ControlNet?> TryGetControlNet()
+    /// <inheritdoc />
+    public async Task<ControlNet?> TryGetControlNet(CancellationToken cancellationToken = default)
     {
         // Get version of controlnet
-        var versionResponse = await FastHttpClient.GetAsync("/controlnet/version");
+        var versionResponse = await FastHttpClient.GetAsync("/controlnet/version", cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Check if exists at all!
         if (versionResponse.StatusCode == HttpStatusCode.NotFound)
@@ -279,7 +327,8 @@ public class StableDiffusion
 
         // Check that it is v2
         var version = await JsonSerializer.DeserializeAsync<ControlNetVersionResponse>(
-            await versionResponse.EnsureSuccessStatusCode().Content.ReadAsStreamAsync()
+            await versionResponse.EnsureSuccessStatusCode().Content.ReadAsStreamAsync(cancellationToken),
+            cancellationToken: cancellationToken
         );
         if (version is not { Version: 2 })
             throw new InvalidOperationException($"Unknown controlnet version: '{version?.Version}'");


### PR DESCRIPTION
Added an optional parameter for a `CancellationToken` to every asynchronous method that makes web calls. This should make it easier to prematurely cancel those requests.
I also added xml exceptions to those methods, as to be able to more easily spot which ones you have to handle. For the `StableDiffusion` class I added them to the interface and used `inheritdoc` to copy them to the class itself.
Let me know if this is a commenting style that's comfortable to you or how I could change it.