### PR TITLE
Clean up credentials from uri after converting to Authorization header

### DIFF
--- a/Autofocus/StableDiffusion.cs
+++ b/Autofocus/StableDiffusion.cs
@@ -64,10 +64,7 @@ public class StableDiffusion
             FastHttpClient = httpClientName == null ? factory.CreateClient() : factory.CreateClient(httpClientName);
         }
 
-        SlowHttpClient.BaseAddress = address;
         SlowHttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Autofocus Agent");
-
-        FastHttpClient.BaseAddress = address;
         FastHttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Autofocus Agent");
 
         if (!string.IsNullOrEmpty(address.UserInfo))
@@ -75,6 +72,16 @@ public class StableDiffusion
             var base64 = Convert.ToBase64String(Encoding.ASCII.GetBytes(address.UserInfo));
             SlowHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
             FastHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
+
+			var builder = new UriBuilder(address) { UserName = null, Password = null };
+			var cleanAddress = builder.Uri;
+			SlowHttpClient.BaseAddress = cleanAddress;
+			FastHttpClient.BaseAddress = cleanAddress;
+		}
+        else
+        {
+            SlowHttpClient.BaseAddress = address;
+            FastHttpClient.BaseAddress = address;
         }
     }
 

--- a/Autofocus/StableDiffusion.cs
+++ b/Autofocus/StableDiffusion.cs
@@ -73,11 +73,11 @@ public class StableDiffusion
             SlowHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
             FastHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
 
-			var builder = new UriBuilder(address) { UserName = null, Password = null };
-			var cleanAddress = builder.Uri;
-			SlowHttpClient.BaseAddress = cleanAddress;
-			FastHttpClient.BaseAddress = cleanAddress;
-		}
+            var builder = new UriBuilder(address) { UserName = null, Password = null };
+            var cleanAddress = builder.Uri;
+            SlowHttpClient.BaseAddress = cleanAddress;
+            FastHttpClient.BaseAddress = cleanAddress;
+        }
         else
         {
             SlowHttpClient.BaseAddress = address;


### PR DESCRIPTION
And the next PR.
Autofocus converts credentials in the address to a base64-encoded Autorization request header. While I'm not sure why this was done there, it works great.
But after that header insertation, it doesn't remove the credentials from the URI and subsequantial requests still go to eg. https://user:password@example.com/, resulting in duplicating the credentials.
This might cause issues, raise security concerns with request logging and, most importantly, causes this code to not work in Chrome-based browsers when using Autofocus this way in a .NET Web Assembly project like Blazor (probably a bug in .NET WASM). [MDN-Link detailing problems in browsers.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#access_using_credentials_in_the_url)
Anyway - this PR cleans up the credentials in the Uri.